### PR TITLE
filter containing extension expression normalization bug fix

### DIFF
--- a/source/Owin.Scim/Querying/ScimFilter.cs
+++ b/source/Owin.Scim/Querying/ScimFilter.cs
@@ -9,7 +9,7 @@
     // TODO: (DG) Add support for fully-qualified URNs
     public class ScimFilter
     {
-        private readonly char[] _schemaSpecialCharacters = { ':', '.', '_', '-' };
+        private static readonly HashSet<char> _schemaSpecialCharacters = new HashSet<char> { ':', '.', '_', '-' };
 
         private readonly ISet<string> _ResourceExtensionSchemas;
 
@@ -277,7 +277,7 @@
                     })).TrimEnd(usedPathDividers.ToArray());
         }
 
-        private bool StillInsideSchema(char currentChar)
+        private static bool StillInsideSchema(char currentChar)
         {
             return char.IsLetterOrDigit(currentChar) || _schemaSpecialCharacters.Contains(currentChar);
         }

--- a/source/Owin.Scim/Querying/ScimFilter.cs
+++ b/source/Owin.Scim/Querying/ScimFilter.cs
@@ -202,7 +202,7 @@
                 if (currentChar == '.' && 
                     !isPathOnly &&
                     !possibleResourceExtension &&
-                    boundaryStack.Peek() != '"')
+                    (!boundaryStack.Any() || boundaryStack.Peek() != '"'))
                 {
                     // we are in a filter expression but not a string literal (valuePath)
                     // (e.g. userType ne \"Employee\" and not (emails co \"example.com\" or emails.value co \"example.org\")

--- a/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
+++ b/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_and_complex_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_and_complex_filter_switched.cs" />
+    <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_exp_at_the_begining_and_complex_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_terminal_attribute_and_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_terminal_attribute_and_grouped_filter.cs" />

--- a/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
+++ b/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
@@ -306,6 +306,8 @@
     <Compile Include="Querying\Filtering\Normalization\with_complex_attribute_no_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_multiple_groups_and_period_within_value_path.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute.cs" />
+    <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_and_complex_filter.cs" />
+    <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_and_complex_filter_switched.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_resource_extension_attribute_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_terminal_attribute_and_filter.cs" />
     <Compile Include="Querying\Filtering\Normalization\with_terminal_attribute_and_grouped_filter.cs" />

--- a/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_and_complex_filter.cs
+++ b/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_and_complex_filter.cs
@@ -1,0 +1,16 @@
+﻿using Machine.Specifications;
+using Owin.Scim.Querying;
+
+namespace Owin.Scim.Tests.Querying.Filtering.Normalization
+{
+    public class with_resource_extension_attribute_and_complex_filter : when_normalizing_a_path_filter
+    {
+        Establish context = () => PathFilter = "(userType eq \"Employee\" or name.givenName eq \"Employee\") and (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\")";
+
+        private It should_contain = () => ScimFilter.Paths.ShouldContainOnly(
+            new PathFilterExpression(null, "(userType eq \"Employee\" or name[givenName eq \"Employee\"]) and (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\")"));
+
+        It should_equal = () =>
+            ScimFilter.NormalizedFilterExpression.ShouldEqual("(userType eq \"Employee\" or name[givenName eq \"Employee\"]) and (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\")");
+    }
+}

--- a/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_and_complex_filter_switched.cs
+++ b/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_and_complex_filter_switched.cs
@@ -1,0 +1,16 @@
+﻿using Machine.Specifications;
+using Owin.Scim.Querying;
+
+namespace Owin.Scim.Tests.Querying.Filtering.Normalization
+{
+    public class with_resource_extension_attribute_and_complex_filter_switched : when_normalizing_a_path_filter
+    {
+        Establish context = () => PathFilter = "(urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\") and (userType eq \"Employee\" or name.givenName eq \"Employee\")";
+
+        private It should_contain = () => ScimFilter.Paths.ShouldContainOnly(
+            new PathFilterExpression(null, "(urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\") and (userType eq \"Employee\" or name[givenName eq \"Employee\"])"));
+
+        It should_equal = () =>
+            ScimFilter.NormalizedFilterExpression.ShouldEqual("(urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\") and (userType eq \"Employee\" or name[givenName eq \"Employee\"])");
+    }
+}

--- a/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_exp_at_the_begining_and_complex_filter.cs
+++ b/source/_tests/Owin.Scim.Tests/Querying/Filtering/Normalization/with_resource_extension_attribute_exp_at_the_begining_and_complex_filter.cs
@@ -1,0 +1,17 @@
+﻿using Machine.Specifications;
+using Owin.Scim.Querying;
+
+namespace Owin.Scim.Tests.Querying.Filtering.Normalization
+{
+    public class with_resource_extension_attribute_exp_at_the_begining_and_complex_filter : when_normalizing_a_path_filter
+    {
+        Establish context = () => PathFilter = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\" and meta.resourceType eq \"User\"";
+
+        private It should_contain = () => ScimFilter.Paths.ShouldContainOnly(
+            new PathFilterExpression("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", null),
+            new PathFilterExpression(null, "employeeNumber eq \"123\" and meta[resourceType eq \"User\"]"));
+
+        It should_equal = () =>
+            ScimFilter.NormalizedFilterExpression.ShouldEqual("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\" and meta[resourceType eq \"User\"]");
+    }
+}


### PR DESCRIPTION
if filter contains expression with extension e.g. 

`(userType eq \"Employee\" or name.givenName eq \"Employee\") and (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\")`

is incorrectly normalized i.e.

`(userType eq \"Employee\" or name[givenName eq \"Employee\"]) and (urn:ietf:params:scim:schemas:extension:enterprise:2[0:User:employeeNumber eq \"123\"])`

and should be of course

`(userType eq \"Employee\" or name[givenName eq \"Employee\"]) and (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber eq \"123\")`

This pull request fixes above issue. New test are added as well.