### PR TITLE
Added support for filtering on datetime (meta.lastModified and meta.created)

### DIFF
--- a/source/Owin.Scim.Antlr/ScimFilter.g4
+++ b/source/Owin.Scim.Antlr/ScimFilter.g4
@@ -54,8 +54,10 @@ fragment DIGIT : [0-9];
 
 fragment ALPHA : [a-z] | [A-Z];
 
+fragment DATETIME: (ALPHA | DIGIT | '_' | '-' | '.'  | ':')+;
+
 ESCAPED_QUOTE : '\\"';
 
-VALUE : '"'(ESCAPED_QUOTE | ~'"')*'"' | 'true' | 'false' | 'null' | DIGIT+('.'DIGIT+)?;
+VALUE : '"'(ESCAPED_QUOTE | ~'"')*'"' | 'true' | 'false' | 'null' | DIGIT+('.'DIGIT+)? | DATETIME+('.'DATETIME+)?;
 
 EXCLUDE : [\b | \t | \r | \n]+ -> skip;


### PR DESCRIPTION
Added support for filtering on datetime (meta.lastModified and meta.created).

This request now works:

```
localhost:8080/scim/v2/users?filter=meta.lastModified+ge+"2011-05-14T04:42:34Z"
```

Before, the Owin.Scim only parsed "2011" from the VALUE. This could *not* be converted to a DateTime and hence threw an error. By including the characters: ALPHA, -, . and : in the VALUE, the entire UTC datetime is parsed "2011-05-14T04:42:34Z" in the VALUE and subsequently converted to DateTime.


Note - I noticed that filtering on string is still not possible:

```
localhost:8080/scim/v2/users?filter=username+eq+"p.van.der.heijden"
```

Tried to fix it right away, but can't find it yet. Any suggestions are welcome!