### PR TITLE
Update Antlr4 packages to fix building in VS2017

### DIFF
--- a/deployment/owin-scim-host/owin-scim-host.csproj
+++ b/deployment/owin-scim-host/owin-scim-host.csproj
@@ -25,6 +25,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -48,9 +49,8 @@
       <HintPath>..\..\Packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.2\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/deployment/owin-scim-host/packages.config
+++ b/deployment/owin-scim-host/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net452" />
-  <package id="Antlr4.Runtime" version="4.5.3" targetFramework="net452" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net452" />
   <package id="bootstrap" version="3.3.7" targetFramework="net452" />
   <package id="jQuery" version="2.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net452" />

--- a/samples/ConsoleHost/ConsoleHost/ConsoleHost.csproj
+++ b/samples/ConsoleHost/ConsoleHost/ConsoleHost.csproj
@@ -34,9 +34,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Autofac, Version=4.2.1.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\..\..\Packages\Autofac.4.2.1\lib\net45\Autofac.dll</HintPath>

--- a/samples/ConsoleHost/ConsoleHost/packages.config
+++ b/samples/ConsoleHost/ConsoleHost/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.5.3" targetFramework="net451" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net451" />
   <package id="Autofac" version="4.2.1" targetFramework="net451" />
   <package id="AutoMapper" version="5.2.0" targetFramework="net451" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net451" />

--- a/source/Owin.Scim.Antlr/Owin.Scim.Antlr.csproj
+++ b/source/Owin.Scim.Antlr/Owin.Scim.Antlr.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\Packages\Antlr4.4.5.3\build\Antlr4.props" Condition="Exists('..\..\Packages\Antlr4.4.5.3\build\Antlr4.props')" />
+  <Import Project="..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props" Condition="Exists('..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,9 +36,8 @@
     <DocumentationFile>..\lib\Owin.Scim.Antlr.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -61,23 +60,21 @@
     </Antlr4>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\Packages\Antlr4.4.5.3\build\Antlr4.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Packages\Antlr4.4.5.3\build\Antlr4.props'))" />
-    <Error Condition="!Exists('..\..\Packages\Antlr4.4.5.3\build\Antlr4.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Packages\Antlr4.4.5.3\build\Antlr4.targets'))" />
-  </Target>
-  <Import Project="..\..\Packages\Antlr4.4.5.3\build\Antlr4.targets" Condition="Exists('..\..\Packages\Antlr4.4.5.3\build\Antlr4.targets')" />
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.props'))" />
+    <Error Condition="!Exists('..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets'))" />
+  </Target>
+  <Import Project="..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets" Condition="Exists('..\..\Packages\Antlr4.CodeGenerator.4.6.6\build\Antlr4.CodeGenerator.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Owin.Scim.Antlr/packages.config
+++ b/source/Owin.Scim.Antlr/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4" version="4.5.3" targetFramework="net45" developmentDependency="true" />
-  <package id="Antlr4.Runtime" version="4.5.3" targetFramework="net45" />
+  <package id="Antlr4" version="4.6.6" targetFramework="net45" developmentDependency="true" />
+  <package id="Antlr4.CodeGenerator" version="4.6.6" targetFramework="net45" developmentDependency="true" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net45" />
 </packages>

--- a/source/Owin.Scim/Owin.Scim.csproj
+++ b/source/Owin.Scim/Owin.Scim.csproj
@@ -37,9 +37,8 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\..\Packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="FluentValidation, Version=6.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\FluentValidation.6.2.1.0\lib\Net45\FluentValidation.dll</HintPath>

--- a/source/Owin.Scim/packages.config
+++ b/source/Owin.Scim/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.5.3" targetFramework="net451" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net451" />
   <package id="DryIoc" version="2.5.1" targetFramework="net451" developmentDependency="true" />
   <package id="DryIoc.Owin" version="2.0.1" targetFramework="net451" developmentDependency="true" />
   <package id="DryIoc.WebApi" version="2.1.0" targetFramework="net451" developmentDependency="true" />

--- a/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
+++ b/source/_tests/Owin.Scim.Tests/Owin.Scim.Tests.csproj
@@ -33,9 +33,8 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime, Version=4.5.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
-      <HintPath>..\..\..\Packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\..\..\Packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.3.1.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\..\..\Packages\FakeItEasy.2.3.1\lib\net40\FakeItEasy.dll</HintPath>

--- a/source/_tests/Owin.Scim.Tests/packages.config
+++ b/source/_tests/Owin.Scim.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Antlr4.Runtime" version="4.5.3" targetFramework="net451" />
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net451" />
   <package id="AutoFixture" version="3.50.2" targetFramework="net451" />
   <package id="FakeItEasy" version="2.3.1" targetFramework="net451" />
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net451" />


### PR DESCRIPTION
Updating to the current versions of Antlr4 and the runtime to correct some build issues related to VS references to EF assemblies and possibly others. Projects all successfully build now following a nuget restore in VS2017.